### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
+arch:
+  - amd64
+  - ppc64le
 language: python
 python:
     - "2.7"
     - "3.4"
+    - "3.7"
+    - "3.8"
 script: python ./setup.py install && python -c "import speg"


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM. The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/debian-speg/builds/209601275 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!
